### PR TITLE
Add router factory classes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Setup Python
@@ -44,7 +44,7 @@ jobs:
           python -m pytest --cov=./ --cov-report=xml --verbose
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.0.2
-        if: ${{ matrix.python-version }} == 3.7
+        if: ${{ matrix.python-version }} == 3.8
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,6 +1,8 @@
 """
 Helper functions to use a FastAPI dependencies.
 """
+from typing import List
+
 import cachey
 import xarray as xr
 from fastapi import Depends
@@ -9,7 +11,7 @@ from .utils.api import DATASET_ID_ATTR_KEY
 from .utils.zarr import create_zmetadata, create_zvariables, zarr_metadata_key
 
 
-def get_dataset_ids():
+def get_dataset_ids() -> List[str]:
     """FastAPI dependency for getting the list of ids (string keys)
     of the collection of datasets being served.
 
@@ -23,7 +25,7 @@ def get_dataset_ids():
     return []  # pragma: no cover
 
 
-def get_dataset(dataset_id: str):
+def get_dataset(dataset_id: str) -> xr.Dataset:
     """FastAPI dependency for accessing the published xarray dataset object.
 
     Use this callable as dependency in any FastAPI path operation
@@ -33,10 +35,10 @@ def get_dataset(dataset_id: str):
     application.
 
     """
-    return None  # pragma: no cover
+    return xr.Dataset()
 
 
-def get_cache():
+def get_cache() -> cachey.Cache:
     """FastAPI dependency for accessing the application's cache.
 
     Use this callable as dependency in any FastAPI path operation
@@ -47,7 +49,7 @@ def get_cache():
     application.
 
     """
-    return None  # pragma: no cover
+    return cachey.Cache(available_bytes=1e6)
 
 
 def get_zvariables(

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -4,7 +4,7 @@ import xarray as xr
 from fastapi import FastAPI, HTTPException
 
 from .dependencies import get_cache, get_dataset, get_dataset_ids
-from .routers import base_router, common_router, dataset_collection_router, zarr_router
+from .routers import BaseFactory, ZarrFactory, common_router, dataset_collection_router
 from .utils.api import (
     SingleDatasetOpenAPIOverrider,
     check_route_conflicts,
@@ -53,8 +53,8 @@ def _set_app_routers(dataset_routers=None, dataset_route_prefix=''):
     # dataset-specifc api endpoints
     if dataset_routers is None:
         dataset_routers = [
-            (base_router, {'tags': ['info']}),
-            (zarr_router, {'tags': ['zarr']}),
+            (BaseFactory().router, {'tags': ['info']}),
+            (ZarrFactory().router, {'tags': ['zarr']}),
         ]
 
     app_routers += normalize_app_routers(dataset_routers, dataset_route_prefix)

--- a/xpublish/routers/__init__.py
+++ b/xpublish/routers/__init__.py
@@ -1,3 +1,3 @@
-from .base import base_router
+from .base import BaseFactory
 from .common import common_router, dataset_collection_router
-from .zarr import zarr_router
+from .zarr import ZarrFactory

--- a/xpublish/routers/factory.py
+++ b/xpublish/routers/factory.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+from typing import Callable, List
+
+import cachey
+import xarray as xr
+from fastapi import APIRouter
+
+from ..dependencies import get_cache, get_dataset, get_dataset_ids
+
+
+@dataclass
+class XpublishFactory:
+    """Xpublish API router factory."""
+
+    router: APIRouter = field(default_factory=APIRouter)
+
+    dataset_ids_dependency: Callable[..., List[str]] = get_dataset_ids
+    dataset_dependency: Callable[..., xr.Dataset] = get_dataset
+    cache_dependency: Callable[..., cachey.Cache] = get_cache
+
+    def __post_init__(self):
+        self.register_routes()
+
+    def register_routes(self):
+        """Register xpublish routes."""
+        raise NotImplementedError()

--- a/xpublish/routers/zarr.py
+++ b/xpublish/routers/zarr.py
@@ -1,86 +1,103 @@
 import json
 import logging
+from dataclasses import dataclass
 
 import cachey
 import xarray as xr
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import Depends, HTTPException
 from starlette.responses import Response
 from zarr.storage import array_meta_key, attrs_key, group_meta_key
 
-from ..dependencies import get_cache, get_dataset, get_zmetadata as _get_zmetadata, get_zvariables
+from ..dependencies import get_cache, get_dataset, get_zmetadata, get_zvariables
 from ..utils.api import DATASET_ID_ATTR_KEY
 from ..utils.cache import CostTimer
 from ..utils.zarr import encode_chunk, get_data_chunk, jsonify_zmetadata, zarr_metadata_key
+from .factory import XpublishFactory
 
-logger = logging.getLogger('api')
-
-zarr_router = APIRouter()
-
-
-@zarr_router.get(f'/{zarr_metadata_key}')
-def get_zmetadata(
-    dataset: xr.Dataset = Depends(get_dataset), zmetadata: dict = Depends(_get_zmetadata)
-):
-    zjson = jsonify_zmetadata(dataset, zmetadata)
-
-    return Response(json.dumps(zjson).encode('ascii'), media_type='application/json')
+logger = logging.getLogger('zarr_api')
 
 
-@zarr_router.get(f'/{group_meta_key}')
-def get_zgroup(zmetadata: dict = Depends(_get_zmetadata)):
+@dataclass
+class ZarrFactory(XpublishFactory):
+    """Provides access to data and metadata through as Zarr compatible API."""
 
-    return zmetadata['metadata'][group_meta_key]
+    def register_routes(self):
+        @self.router.get(f'/{zarr_metadata_key}')
+        def get_zarr_metadata(
+            dataset=Depends(self.dataset_dependency),
+            cache=Depends(self.cache_dependency),
+        ):
+            zvariables = get_zvariables(dataset, cache)
+            zmetadata = get_zmetadata(dataset, cache, zvariables)
 
+            zjson = jsonify_zmetadata(dataset, zmetadata)
 
-@zarr_router.get(f'/{attrs_key}')
-def get_zattrs(zmetadata: dict = Depends(_get_zmetadata)):
+            return Response(json.dumps(zjson).encode('ascii'), media_type='application/json')
 
-    return zmetadata['metadata'][attrs_key]
+        @self.router.get(f'/{group_meta_key}')
+        def get_zarr_group(
+            dataset=Depends(self.dataset_dependency),
+            cache=Depends(self.cache_dependency),
+        ):
+            zvariables = get_zvariables(dataset, cache)
+            zmetadata = get_zmetadata(dataset, cache, zvariables)
 
+            return zmetadata['metadata'][group_meta_key]
 
-@zarr_router.get('/{var}/{chunk}')
-def get_variable_chunk(
-    var: str,
-    chunk: str,
-    dataset: xr.Dataset = Depends(get_dataset),
-    cache: cachey.Cache = Depends(get_cache),
-    zvariables: dict = Depends(get_zvariables),
-    zmetadata: dict = Depends(_get_zmetadata),
-):
-    """Get a zarr array chunk.
+        @self.router.get(f'/{attrs_key}')
+        def get_zarr_attrs(
+            dataset=Depends(self.dataset_dependency),
+            cache=Depends(self.cache_dependency),
+        ):
+            zvariables = get_zvariables(dataset, cache)
+            zmetadata = get_zmetadata(dataset, cache, zvariables)
 
-    This will return cached responses when available.
+            return zmetadata['metadata'][attrs_key]
 
-    """
-    # First check that this request wasn't for variable metadata
-    if array_meta_key in chunk:
-        return zmetadata['metadata'][f'{var}/{array_meta_key}']
-    elif attrs_key in chunk:
-        return zmetadata['metadata'][f'{var}/{attrs_key}']
-    elif group_meta_key in chunk:
-        raise HTTPException(status_code=404, detail='No subgroups')
-    else:
-        logger.debug('var is %s', var)
-        logger.debug('chunk is %s', chunk)
+        @self.router.get('/{var}/{chunk}')
+        def get_variable_chunk(
+            var: str,
+            chunk: str,
+            dataset: xr.Dataset = Depends(get_dataset),
+            cache: cachey.Cache = Depends(get_cache),
+        ):
+            """Get a zarr array chunk.
 
-        cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + f'{var}/{chunk}'
-        response = cache.get(cache_key)
+            This will return cached responses when available.
 
-        if response is None:
-            with CostTimer() as ct:
-                arr_meta = zmetadata['metadata'][f'{var}/{array_meta_key}']
-                da = zvariables[var].data
+            """
+            zvariables = get_zvariables(dataset, cache)
+            zmetadata = get_zmetadata(dataset, cache, zvariables)
 
-                data_chunk = get_data_chunk(da, chunk, out_shape=arr_meta['chunks'])
+            # First check that this request wasn't for variable metadata
+            if array_meta_key in chunk:
+                return zmetadata['metadata'][f'{var}/{array_meta_key}']
+            elif attrs_key in chunk:
+                return zmetadata['metadata'][f'{var}/{attrs_key}']
+            elif group_meta_key in chunk:
+                raise HTTPException(status_code=404, detail='No subgroups')
+            else:
+                logger.debug('var is %s', var)
+                logger.debug('chunk is %s', chunk)
 
-                echunk = encode_chunk(
-                    data_chunk.tobytes(),
-                    filters=arr_meta['filters'],
-                    compressor=arr_meta['compressor'],
-                )
+                cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + f'{var}/{chunk}'
+                response = cache.get(cache_key)
 
-                response = Response(echunk, media_type='application/octet-stream')
+                if response is None:
+                    with CostTimer() as ct:
+                        arr_meta = zmetadata['metadata'][f'{var}/{array_meta_key}']
+                        da = zvariables[var].data
 
-            cache.put(cache_key, response, ct.time, len(echunk))
+                        data_chunk = get_data_chunk(da, chunk, out_shape=arr_meta['chunks'])
 
-        return response
+                        echunk = encode_chunk(
+                            data_chunk.tobytes(),
+                            filters=arr_meta['filters'],
+                            compressor=arr_meta['compressor'],
+                        )
+
+                        response = Response(echunk, media_type='application/octet-stream')
+
+                    cache.put(cache_key, response, ct.time, len(echunk))
+
+                return response


### PR DESCRIPTION
This is very much inspired from [titiler](https://github.com/developmentseed/titiler). It will provide more flexibility for e.g., choosing alternative default values for some parameters (e.g., projection or colormap for xyz/wms services #88).

One question: should we force users to subclass `XpublishFactory` or should we still allow them providing "raw" FastAPI routers to xpublish applications?

Using `XpublishFactory` exclusively would allow us to get rid of FastAPI's dependencies overriding (it always seemed hacky to me in this context) and some ugly workarounds like https://github.com/xarray-contrib/xpublish/commit/13bed4ba04b664d6b772222379c6889bcbe6278b.

On the other hand, I like that users can simply create an `APIRouter` with a bunch of functions. Also no breaking change in this case.

Thoughts @xarray-contrib/xpublish-devs?
