### PR TITLE
build: Remove minimum versions in requirements.txt, drop python 3.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 fsspec
 httpx
-importlib-metadata>=4.13.0
+importlib-metadata
 netcdf4
 pooch
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 cachey
 dask
-fastapi>=0.59
+fastapi
 numcodecs
-numpy>=1.17
+numpy
 pluggy
 toolz
 uvicorn
-xarray>=0.16
+xarray
 zarr

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ CLASSIFIERS = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Previously, some of the Xpublish's dependencies had lower bounds. However, these lower bounds were far out of date. They have been removed. Python 3.8 was also removed from our CI system.

BREAKING CHANGE: drop python 3.8 support

(towards debugging #188)