### PR TITLE
Support reading scalar variables through the zarr plugin

### DIFF
--- a/tests/test_zarr_compat.py
+++ b/tests/test_zarr_compat.py
@@ -1,5 +1,6 @@
 import json
 
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -247,5 +248,21 @@ def test_roundtrip_custom_chunks(
     ds = ds.chunk(chunks)
     mapper = TestMapper(SingleDatasetRest(ds).app)
     actual = xr.open_zarr(mapper, consolidated=True, decode_times=decode_times)
+
+    xr.testing.assert_identical(actual, ds)
+
+
+def test_scalar_variable():
+    ds = xr.Dataset(
+        {
+            'scalar': xr.DataArray(
+                np.float32(0.0),
+                dims=(),
+                name='scalar',
+            )
+        }
+    )
+    mapper = TestMapper(SingleDatasetRest(ds).app)
+    actual = xr.open_zarr(mapper, consolidated=True)
 
     xr.testing.assert_identical(actual, ds)

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -178,7 +178,7 @@ def get_data_chunk(da, chunk_id, out_shape):
     if isinstance(da, dask_array_type):
         chunk_data = da.blocks[ikeys]
     else:
-        if ikeys != ((0,) * da.ndim):
+        if da.ndim > 0 and ikeys != ((0,) * da.ndim):
             raise ValueError(
                 'Invalid chunk_id for numpy array: %s. Should have been: %s'
                 % (chunk_id, ((0,) * da.ndim))


### PR DESCRIPTION
Reading scalar variables through the zarr plugin is erroring with a `ValueError: Invalid chunk_id for numpy array: 0. Should have been: ()`. This is due to `((0,) * da.ndim)` being `()` when `ndims = 0`. In turn, that does not match the requested chunk `(0,)` so the exception is raised.. This removes the invalid `chunk_id` check when dealing with scalar variables (`ndim = 0`). The added test fails without the change.