### PR TITLE
Include Github releases in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-autodoc-typehints
 autodoc_pydantic
 myst-nb
 sphinx-design
+sphinx_github_changelog

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+```{changelog}
+---
+changelog-url: https://xpublish.readthedocs.io/en/latest/changelog.html
+github: https://github.com/xpublish-community/xpublish/releases
+pypi: https://pypi.org/project/xpublish/
+---
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     'sphinx_design',
     'myst_parser',
+    'sphinx_github_changelog',
 ]
 
 myst_enable_extensions = []
@@ -151,6 +152,7 @@ html_theme_options = {
         }
     ],
     'use_edit_page_button': True,
+    'header_links_before_dropdown': 4,
 }
 
 html_context = {

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -115,6 +115,7 @@ user-guide/index
 api
 ecosystem/index
 Contributing <contributing>
+changelog
 ```
 
 ## Feedback


### PR DESCRIPTION
Uses https://sphinx-github-changelog.readthedocs.io/en/latest/ to pull the changelog from Github Releases.

Requires `SPHINX_GITHUB_CHANGELOG_TOKEN` to be set to build the changelog.