### PR TITLE
Separate pip caches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,24 +15,33 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - uses: actions/cache@v3.3.1
+
+      - name: Setup pip cache
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/dev-requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
-      - run: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}
+            ${{ runner.os }}-pip
+            ${{ runner.os }}-pip-dev
+
+      - name: Install dependencies
+        run: |
           python -m pip install -r dev-requirements.txt
           python -m pip install --no-deps -e .
           python -m pip list
+
       - name: Running Tests
         run: |
           python -m pytest --cov=./ --cov-report=xml --verbose
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.3
         if: ${{ matrix.python-version }} == 3.9
@@ -48,18 +57,25 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - uses: actions/cache@v3.3.1
+
+      - name: Setup pip cache
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
+          key: ${{ runner.os }}-pip-dev-${{ matrix.python-version }}-${{ hashFiles('**/dev-requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
-      - run: |
+            ${{ runner.os }}-pip-dev-${{ matrix.python-version }}
+            ${{ runner.os }}-pip-dev
+            ${{ runner.os }}-pip
+
+      - name: Install dev dependencies
+        run: |
           python -m pip install -r dev-requirements.txt
           python -m pip install --no-deps --upgrade \
                 git+https://github.com/dask/dask \
@@ -70,6 +86,7 @@ jobs:
                 git+https://github.com/encode/uvicorn
           python -m pip install --no-deps -e .
           python -m pip list
+
       - name: Running Tests
         run: |
           python -m pytest --verbose


### PR DESCRIPTION
Pip was using the same cache for multiple versions, so for Python version specific packages they were almost always missing the cache.

This PR keeps a cache per Python version and separate ones for the upstream tests as well. The cache restore keys allow sharing between versions or between the upstream and regular tests.