### PR TITLE
Experimenting with Dask integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cachey
 dask
+distributed
 fastapi
 numcodecs
 numpy

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
             'zarr = xpublish.plugins.included.zarr:ZarrPlugin',
             'module_version = xpublish.plugins.included.module_version:ModuleVersionPlugin',
             'plugin_info = xpublish.plugins.included.plugin_info:PluginInfoPlugin',
+            # 'dask_client = xpublish.plugins.included.dask_client:DaskClientPlugin',
+            # 'dask_local_cluster = xpublish.plugins.included.dask_local_cluster:DaskLocalClusterPlugin',
         ]
     },
 )

--- a/xpublish/plugins/included/dask_client.py
+++ b/xpublish/plugins/included/dask_client.py
@@ -1,0 +1,31 @@
+"""
+Default Dask clients
+"""
+from dask import distributed
+from pydantic import Field
+
+from .. import Plugin, hookimpl
+
+
+class DaskClientPlugin(Plugin):
+    name = 'dask_client'
+
+    sync_kwargs: dict = Field(
+        default_factory=dict, description='Keyword arguments for syncronous Dask distributed.Client'
+    )
+    async_kwargs: dict = Field(
+        default_factory=dict,
+        description='Keyword arguments for asyncronous Dask distributed.Client',
+    )
+
+    @hookimpl(trylast=True)
+    def get_dask_sync_client(self, cluster: distributed.SpecCluster):
+        client = distributed.Client(cluster, **self.sync_kwargs)
+
+        return client
+
+    @hookimpl(trylast=True)
+    def get_dask_async_client(self, cluster: distributed.SpecCluster):
+        client = distributed.Client(cluster, asynchronous=True, **self.async_kwargs)
+
+        return client

--- a/xpublish/plugins/included/dask_local_cluster.py
+++ b/xpublish/plugins/included/dask_local_cluster.py
@@ -1,0 +1,20 @@
+"""
+Default Dask local cluster
+"""
+from dask import distributed
+
+from .. import Plugin, hookimpl
+
+
+class DaskLocalClusterPlugin(Plugin):
+    name = 'dask_local_cluster'
+
+    @hookimpl(trylast=True)
+    def get_dask_cluster(self):
+        """Creates a local Dask cluster"""
+        try:
+            return self._cluster
+        except AttributeError:
+            cluster = distributed.LocalCluster()
+            self._cluster = cluster
+            return cluster


### PR DESCRIPTION
After the Dask discussion two weeks ago (see https://github.com/orgs/xpublish-community/discussions/4) I sat down and sketched out what an implementation could look like in Xpublish. It's really rough, and throughly un-tested. 

This adds two local plugins and associated infrastructure for most hooks to be able to use Dask.

In most cases for different types of Dask infrastruture, a plugin that provides a `get_dask_cluster()` method should do the trick. The hook is set up to only return one result, and the built in plugin will be the last.

The Dask client plugin in theory should work with different types of clusters, but is similarly set up to be able to be overridden (dask-on-ray?). The client can be both sync and async, and once it gets accessed, it's cached on `xpublish.Rest`.

For hooks that have access to `deps` (which now includes dataset providers), `deps.dask_sync_client` and `deps.dask_async_client` now should give you the client.

The async client may need to be passed the current event loop. It appears the way to access the event loop varies by server, so that will probably take some research.
- https://github.com/tiangolo/fastapi/discussions/7876
- https://github.com/encode/uvicorn/issues/706
- https://stackoverflow.com/questions/66275747/how-to-use-event-loop-created-by-uvicorn