### PR TITLE
Anti-pin the latest version of Xarray to fix Zarr roundtrip tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,5 +16,5 @@ pytest-cov
 requests
 toolz
 uvicorn
-xarray
+xarray!=v2023.09.0  # see https://github.com/xpublish-community/xpublish/issues/237
 zarr

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy
 pluggy
 toolz
 uvicorn
-xarray
+xarray!=v2023.09.0  # see https://github.com/xpublish-community/xpublish/issues/237
 zarr


### PR DESCRIPTION
v2023.09.0 of Xarray caused our Zarr roundtrip tests to fail as times no longer matched.

For full details see https://github.com/xpublish-community/xpublish/issues/237

The fix looks to have landed in https://github.com/pydata/xarray/pull/8272 and tests against the latest commit works, so we'll go with setting an pin to skip just v2023.09.0.

Closes #237