### PR TITLE
Docstring improvements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ numcodecs
 numpy
 pluggy
 pooch
+pre-commit
 pytest
 pytest-mock
 pytest-sugar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ skip-string-normalization = true
 select = [
     "B", # flake8-bugbear
     "C",
+    'D', # pydocstyle
     "E", # pycodestyle
     "F", # Pyflakes
     "I", # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ select = [
     "B9",
 ]
 ignore = [
+    "D100", # Missing docstring in public module
+    "D107", # Missing docstring in `__init__`
+    "D104", # Missing docstring in public package
     # "E203",
     # "E266",
     "E501",
@@ -79,6 +82,10 @@ ignore = [
     "C901",
 ]
 line-length = 100
+exclude = [
+    "tests/",
+    "docs/",
+]
 
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,14 @@ known-third-party = [
     "zarr",
 ]
 
+[tool.ruff.lint.pydocstyle]
+# Use Google style docstrings
+convention = "google"
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+docstring-quotes = "double"
+
 [tool.ruff.flake8-bugbear]
 # Allow fastapi.Depends and other dependency injection style function arguments
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path"]

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -208,12 +208,8 @@ def test_uninitialized_plugin(uninitialized_dataset_plugin):
     """Checks for custom AttributeError message when plugin is not initialized."""
     rest = Rest({})
 
-    try:
+    with pytest.raises(AttributeError, match='Plugin'):
         rest.register_plugin(uninitialized_dataset_plugin)
-    except AttributeError as e:
-        assert 'Plugin' in str(e)
-    else:
-        assert False, 'Expected AttributeError'
 
 
 def test_custom_plugin_hooks_register(hook_spec_plugin, hook_implementation_plugin):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,9 +11,7 @@ rs = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(123456789)))
 
 
 class TestMapper(TestClient, BaseStore):
-    """
-    A simple subclass to support getitem syntax on Starlette TestClient Objects
-    """
+    """A simple subclass to support getitem syntax on Starlette TestClient Objects"""
 
     def __getitem__(self, key):
         zarr_key = f'/zarr/{key}'
@@ -49,7 +47,6 @@ def create_dataset(
     use_xy_dim=False,
 ):
     """Utility function for creating test data"""
-
     if use_cftime:
         end = xr.coding.cftime_offsets.to_cftime_datetime(end, calendar=calendar)
         dates = xr.cftime_range(start=start, end=end, freq=freq, calendar=calendar)

--- a/xpublish/__init__.py
+++ b/xpublish/__init__.py
@@ -1,3 +1,4 @@
+"""Publish a Xarray Dataset through a rest API."""
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:

--- a/xpublish/accessor.py
+++ b/xpublish/accessor.py
@@ -29,7 +29,7 @@ class RestAccessor:
 
         NOTE: This method can only be invoked once.
 
-        Args: 
+        Args:
             **kwargs: Arguments passed to :func:`xpublish.SingleDatasetRest.__init__`.
 
         Returns:
@@ -59,7 +59,7 @@ class RestAccessor:
         """Serve this FastAPI application via :func:`uvicorn.run`.
 
         NOTE: This method is blocking and does not return.
-        
+
         Args:
             **kwargs: Arguments passed to :func:`xpublish.SingleDatasetRest.serve`.
         """

--- a/xpublish/accessor.py
+++ b/xpublish/accessor.py
@@ -46,13 +46,11 @@ class RestAccessor:
     @property
     def cache(self) -> cachey.Cache:
         """Returns the :class:`cachey.Cache` instance used by the FastAPI application."""
-
         return self._get_rest_obj().cache
 
     @property
     def app(self) -> FastAPI:
         """Returns the :class:`fastapi.FastAPI` application instance."""
-
         return self._get_rest_obj().app
 
     def serve(self, **kwargs):

--- a/xpublish/accessor.py
+++ b/xpublish/accessor.py
@@ -7,10 +7,7 @@ from .rest import SingleDatasetRest
 
 @xr.register_dataset_accessor('rest')
 class RestAccessor:
-    """REST API Accessor for serving one dataset in its
-    dedicated FastAPI application.
-
-    """
+    """REST API Accessor for serving one dataset via a dedicated FastAPI app."""
 
     def __init__(self, xarray_obj):
         self._obj = xarray_obj

--- a/xpublish/accessor.py
+++ b/xpublish/accessor.py
@@ -27,15 +27,13 @@ class RestAccessor:
     def __call__(self, **kwargs):
         """Initialize this accessor by setting optional configuration values.
 
-        Parameters
-        ----------
-        **kwargs
-            Arguments passed to :func:`xpublish.SingleDatasetRest.__init__`.
+        NOTE: This method can only be invoked once.
 
-        Notes
-        -----
-        This method can only be invoked once.
+        Args: 
+            **kwargs: Arguments passed to :func:`xpublish.SingleDatasetRest.__init__`.
 
+        Returns:
+            The initialized accessor.
         """
         if self._initialized:
             raise RuntimeError('This accessor has already been initialized')
@@ -60,14 +58,9 @@ class RestAccessor:
     def serve(self, **kwargs):
         """Serve this FastAPI application via :func:`uvicorn.run`.
 
-        Parameters
-        ----------
-        **kwargs :
-            Arguments passed to :func:`xpublish.SingleDatasetRest.serve`.
-
-        Notes
-        -----
-        This method is blocking and does not return.
-
+        NOTE: This method is blocking and does not return.
+        
+        Args:
+            **kwargs: Arguments passed to :func:`xpublish.SingleDatasetRest.serve`.
         """
         self._get_rest_obj().serve(**kwargs)

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,5 +1,4 @@
-"""Helper functions to use a FastAPI dependencies.
-"""
+"""Helper functions to use a FastAPI dependencies."""
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -19,8 +18,7 @@ if TYPE_CHECKING:
 
 
 def get_dataset_ids() -> List[str]:
-    """FastAPI dependency for getting the list of ids (string keys)
-    of the collection of datasets being served.
+    """FastAPI dependency for getting the list of ids (string keys) of the collection of datasets being served.
 
     Use this callable as dependency in any FastAPI path operation
     function where you need access to those ids.
@@ -103,6 +101,7 @@ def get_zmetadata(
     Args:
         dataset: The dataset to get the zmetadata from.
         cache: The cache to use for storing the zmetadata.
+        zvariables: The zvariables to use for creating the zmetadata.
 
     Returns:
         A consolidated zmetadata dictionary.
@@ -120,7 +119,7 @@ def get_zmetadata(
 
 
 def get_plugins() -> Dict[str, 'Plugin']:
-    """FastAPI dependency that returns the a dictionary of loaded plugins
+    """FastAPI dependency that returns the a dictionary of loaded plugins.
 
     Returns:
         Dictionary of names to initialized plugins.
@@ -129,5 +128,5 @@ def get_plugins() -> Dict[str, 'Plugin']:
 
 
 def get_plugin_manager() -> pluggy.PluginManager:
-    """Return the active plugin manager"""
+    """Return the active plugin manager."""
     ...

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -98,6 +98,7 @@ def get_zvariables(
 def get_zmetadata(
     dataset: xr.Dataset = Depends(get_dataset),
     cache: cachey.Cache = Depends(get_cache),
+    zvariables: dict = Depends(get_zvariables),
 ) -> dict:
     """FastAPI dependency that returns a consolidated zmetadata dictionary.
 

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,7 +1,11 @@
 """
 Helper functions to use a FastAPI dependencies.
 """
-from typing import TYPE_CHECKING, Dict, List
+from typing import (
+    TYPE_CHECKING, 
+    Dict, 
+    List,
+)
 
 import cachey
 import pluggy
@@ -27,7 +31,6 @@ def get_dataset_ids() -> List[str]:
 
     Returns:
         A list of unique keys for datasets
-
     """
     return []  # pragma: no cover
 
@@ -67,9 +70,18 @@ def get_cache() -> cachey.Cache:
 
 
 def get_zvariables(
-    dataset: xr.Dataset = Depends(get_dataset), cache: cachey.Cache = Depends(get_cache)
-):
-    """FastAPI dependency that returns a dictionary of zarr encoded variables."""
+    dataset: xr.Dataset = Depends(get_dataset), 
+    cache: cachey.Cache = Depends(get_cache),
+) -> dict:
+    """FastAPI dependency that returns a dictionary of zarr encoded variables.
+
+    Args:
+        dataset: The dataset to get the zvariables from.
+        cache: The cache to use for storing the zvariables.
+
+    Returns:
+        A dictionary of zarr encoded variables.
+    """
 
     cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
     zvariables = cache.get(cache_key)
@@ -86,10 +98,16 @@ def get_zvariables(
 def get_zmetadata(
     dataset: xr.Dataset = Depends(get_dataset),
     cache: cachey.Cache = Depends(get_cache),
-    zvariables: dict = Depends(get_zvariables),
-):
-    """FastAPI dependency that returns a consolidated zmetadata dictionary."""
+) -> dict:
+    """FastAPI dependency that returns a consolidated zmetadata dictionary.
 
+    Args:
+        dataset: The dataset to get the zmetadata from.
+        cache: The cache to use for storing the zmetadata.
+
+    Returns:
+        A consolidated zmetadata dictionary.
+    """
     cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + ZARR_METADATA_KEY
     zmeta = cache.get(cache_key)
 
@@ -108,9 +126,9 @@ def get_plugins() -> Dict[str, 'Plugin']:
     Returns:
         Dictionary of names to initialized plugins.
     """
-
     return {}  # pragma: no cover
 
 
 def get_plugin_manager() -> pluggy.PluginManager:
     """Return the active plugin manager"""
+    ...

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,5 +1,4 @@
-"""
-Helper functions to use a FastAPI dependencies.
+"""Helper functions to use a FastAPI dependencies.
 """
 from typing import (
     TYPE_CHECKING,
@@ -82,7 +81,6 @@ def get_zvariables(
     Returns:
         A dictionary of zarr encoded variables.
     """
-
     cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
     zvariables = cache.get(cache_key)
 

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -2,8 +2,8 @@
 Helper functions to use a FastAPI dependencies.
 """
 from typing import (
-    TYPE_CHECKING, 
-    Dict, 
+    TYPE_CHECKING,
+    Dict,
     List,
 )
 
@@ -70,7 +70,7 @@ def get_cache() -> cachey.Cache:
 
 
 def get_zvariables(
-    dataset: xr.Dataset = Depends(get_dataset), 
+    dataset: xr.Dataset = Depends(get_dataset),
     cache: cachey.Cache = Depends(get_cache),
 ) -> dict:
     """FastAPI dependency that returns a dictionary of zarr encoded variables.

--- a/xpublish/plugins/hooks.py
+++ b/xpublish/plugins/hooks.py
@@ -46,13 +46,12 @@ class Dependencies(BaseModel):
     )
 
     def __hash__(self):
-        """Dependency functions aren't easy to hash"""
+        """Dependency functions aren't easy to hash."""
         return 0  # pragma: no cover
 
 
 class Plugin(BaseModel):
-    """Xpublish plugins provide ways to extend the core of xpublish with
-    new routers and other functionality.
+    """Xpublish plugins provide ways to extend the core of xpublish with new routers and other functionality.
 
     To create a plugin, subclass `Plugin` and add attributes that are
     subclasses of `PluginType` (`Router` for instance).
@@ -64,7 +63,7 @@ class Plugin(BaseModel):
     name: str = Field(..., description='Fallback name of plugin')
 
     def __hash__(self):
-        """Make sure that the plugin is hashable to load with pluggy"""
+        """Make sure that the plugin is hashable to load with pluggy."""
         things_to_hash = []
 
         # try/except is for pydantic backwards compatibility
@@ -82,7 +81,9 @@ class Plugin(BaseModel):
         return hash(tuple(things_to_hash))
 
     def __dir__(self) -> Iterable[str]:
-        """We need to override the dir as pluggy will otherwise try to inspect it,
+        """Overrides the dir.
+
+        We need to override the dir as pluggy will otherwise try to inspect it,
         and Pydantic has marked it class only
 
         https://github.com/pydantic/pydantic/pull/1466
@@ -95,7 +96,7 @@ class Plugin(BaseModel):
 
 
 class PluginSpec(Plugin):
-    """Plugin extension points
+    """Plugin extension points.
 
     Plugins do not need to implement all of the methods defined here,
     instead they implement
@@ -103,7 +104,7 @@ class PluginSpec(Plugin):
 
     @hookspec
     def app_router(self, deps: Dependencies) -> APIRouter:  # type: ignore
-        """Create an app (top-level) router for the plugin
+        """Create an app (top-level) router for the plugin.
 
         Implementations should return an APIRouter, and define
         app_router_prefix, and app_router_tags on the class,
@@ -112,7 +113,7 @@ class PluginSpec(Plugin):
 
     @hookspec
     def dataset_router(self, deps: Dependencies) -> APIRouter:  # type: ignore
-        """Create a dataset router for the plugin
+        """Create a dataset router for the plugin.
 
         Implementations should return an APIRouter, and define
         dataset_router_prefix, and dataset_router_tags on the class,
@@ -121,7 +122,7 @@ class PluginSpec(Plugin):
 
     @hookspec
     def get_datasets(self) -> Iterable[str]:  # type: ignore
-        """Return an iterable of dataset ids that the plugin can provide"""
+        """Return an iterable of dataset ids that the plugin can provide."""
 
     @hookspec(firstresult=True)
     # type: ignore
@@ -133,4 +134,4 @@ class PluginSpec(Plugin):
 
     @hookspec
     def register_hookspec(self):  # type: ignore
-        """Return additional hookspec class to register with the plugin manager"""
+        """Return additional hookspec class to register with the plugin manager."""

--- a/xpublish/plugins/hooks.py
+++ b/xpublish/plugins/hooks.py
@@ -16,8 +16,7 @@ hookimpl = pluggy.HookimplMarker('xpublish')
 
 
 class Dependencies(BaseModel):
-    """
-    A set of dependencies that are passed into plugin routers.
+    """A set of dependencies that are passed into plugin routers.
 
     Some routers may be 'borrowed' by other routers to expose different
     geometries of data, thus the default dependencies may need to be overridden.
@@ -52,8 +51,7 @@ class Dependencies(BaseModel):
 
 
 class Plugin(BaseModel):
-    """
-    Xpublish plugins provide ways to extend the core of xpublish with
+    """Xpublish plugins provide ways to extend the core of xpublish with
     new routers and other functionality.
 
     To create a plugin, subclass `Plugin` and add attributes that are

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -21,6 +21,7 @@ class DatasetInfoPlugin(Plugin):
 
     @hookimpl
     def dataset_router(self, deps: Dependencies) -> APIRouter:
+        """Returns a router with dataset metadata and schema routes."""
         router = APIRouter(
             prefix=self.dataset_router_prefix,
             tags=list(self.dataset_router_tags),
@@ -38,14 +39,14 @@ class DatasetInfoPlugin(Plugin):
         def list_keys(
             dataset=Depends(deps.dataset),
         ) -> list[str]:
-            """Returns a of the keys in a dataset"""
+            """Returns a of the keys in a dataset."""
             return JSONResponse(list(dataset.variables))
 
         @router.get('/dict')
         def to_dict(
             dataset=Depends(deps.dataset),
         ) -> dict:
-            """Returns the full dataset as a dictionary"""
+            """Returns the full dataset as a dictionary."""
             return JSONResponse(dataset.to_dict(data=False))
 
         @router.get('/info')

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -31,7 +31,6 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
         ) -> HTMLResponse:
             """Returns the xarray HTML representation of the dataset."""
-
             with xr.set_options(display_style='html'):
                 return HTMLResponse(dataset._repr_html_())
 
@@ -40,7 +39,6 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
         ) -> list[str]:
             """Returns a of the keys in a dataset"""
-
             return JSONResponse(list(dataset.variables))
 
         @router.get('/dict')
@@ -56,7 +54,6 @@ class DatasetInfoPlugin(Plugin):
             cache=Depends(deps.cache),
         ) -> dict:
             """Returns the dataset schema (close to the NCO-JSON schema)."""
-
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -12,7 +12,7 @@ from .. import Dependencies, Plugin, hookimpl
 
 
 class DatasetInfoPlugin(Plugin):
-    """Dataset metadata"""
+    """Dataset metadata and schema routes."""
 
     name: str = 'dataset_info'
 
@@ -39,7 +39,7 @@ class DatasetInfoPlugin(Plugin):
         def list_keys(
             dataset=Depends(deps.dataset),
         ) -> list[str]:
-            """List of the keys in a dataset"""
+            """Returns a of the keys in a dataset"""
 
             return JSONResponse(list(dataset.variables))
 
@@ -47,7 +47,7 @@ class DatasetInfoPlugin(Plugin):
         def to_dict(
             dataset=Depends(deps.dataset),
         ) -> dict:
-            """The full dataset as a dictionary"""
+            """Returns the full dataset as a dictionary"""
             return JSONResponse(dataset.to_dict(data=False))
 
         @router.get('/info')
@@ -55,7 +55,7 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Dataset schema (close to the NCO-JSON schema)."""
+            """Returns the dataset schema (close to the NCO-JSON schema)."""
 
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)

--- a/xpublish/plugins/included/module_version.py
+++ b/xpublish/plugins/included/module_version.py
@@ -12,7 +12,7 @@ from .. import Plugin, hookimpl
 
 
 class ModuleVersionPlugin(Plugin):
-    """Share the currently loaded versions of key libraries"""
+    """Share the currently loaded versions of key libraries."""
 
     name: str = 'module_version'
 
@@ -28,7 +28,7 @@ class ModuleVersionPlugin(Plugin):
 
         @router.get('/versions')
         def get_versions() -> dict:
-            """Currently loaded versions of key libraries"""
+            """Returns a dict with currently loaded versions of key libraries."""
             versions = dict(get_sys_info() + netcdf_and_hdf5_versions())
             modules = [
                 'xarray',

--- a/xpublish/plugins/included/module_version.py
+++ b/xpublish/plugins/included/module_version.py
@@ -1,5 +1,4 @@
-"""
-Version information router
+"""Version information router
 """
 import importlib
 import sys

--- a/xpublish/plugins/included/module_version.py
+++ b/xpublish/plugins/included/module_version.py
@@ -1,5 +1,4 @@
-"""Version information router
-"""
+"""Version information router."""
 import importlib
 import sys
 from typing import Sequence
@@ -20,6 +19,7 @@ class ModuleVersionPlugin(Plugin):
 
     @hookimpl
     def app_router(self) -> APIRouter:
+        """Return a router with module version information."""
         router = APIRouter(
             prefix=self.app_router_prefix,
             tags=self.app_router_tags,

--- a/xpublish/plugins/included/plugin_info.py
+++ b/xpublish/plugins/included/plugin_info.py
@@ -16,7 +16,7 @@ class PluginInfo(BaseModel):
 
 
 class PluginInfoPlugin(Plugin):
-    """Expose plugin source and version"""
+    """Expose the currently loaded plugins and their versions."""
 
     name: str = 'plugin_info'
 
@@ -34,7 +34,7 @@ class PluginInfoPlugin(Plugin):
         def get_plugins(
             plugins: Dict[str, Plugin] = Depends(deps.plugins)
         ) -> Dict[str, PluginInfo]:
-            """Return the source and version of the currently loaded plugins"""
+            """Return the source and version of the currently loaded plugins."""
             plugin_info = {}
 
             for name, plugin in plugins.items():

--- a/xpublish/plugins/included/plugin_info.py
+++ b/xpublish/plugins/included/plugin_info.py
@@ -1,5 +1,4 @@
-"""Plugin information router
-"""
+"""Plugin information router."""
 import importlib
 from typing import Dict, Optional, Sequence
 
@@ -10,6 +9,8 @@ from .. import Dependencies, Plugin, hookimpl
 
 
 class PluginInfo(BaseModel):
+    """Pydantic schema for plugin info."""
+
     path: str
     version: Optional[str] = None
 
@@ -24,6 +25,7 @@ class PluginInfoPlugin(Plugin):
 
     @hookimpl
     def app_router(self, deps: Dependencies) -> APIRouter:
+        """Returns the router for plugin info metadata."""
         router = APIRouter(
             prefix=self.app_router_prefix,
             tags=list(self.app_router_tags),

--- a/xpublish/plugins/included/plugin_info.py
+++ b/xpublish/plugins/included/plugin_info.py
@@ -1,5 +1,4 @@
-"""
-Plugin information router
+"""Plugin information router
 """
 import importlib
 from typing import Dict, Optional, Sequence

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -33,6 +33,7 @@ class ZarrPlugin(Plugin):
 
     @hookimpl
     def dataset_router(self, deps: Dependencies) -> APIRouter:
+        """Returns a router with Zarr-like accessing endpoints for datasets."""
         router = APIRouter(
             prefix=self.dataset_router_prefix,
             tags=list(self.dataset_router_tags),

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -24,7 +24,7 @@ logger = logging.getLogger('zarr_api')
 
 
 class ZarrPlugin(Plugin):
-    """Adds Zarr-like accessing endpoints for datasets"""
+    """Adds Zarr-like accessing endpoints for datasets."""
 
     name: str = 'zarr'
 
@@ -43,7 +43,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Consolidated Zarr metadata"""
+            """Returns consolidated Zarr metadata."""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 
@@ -56,7 +56,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Zarr group data"""
+            """Returns Zarr group data."""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 
@@ -67,7 +67,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Zarr attributes"""
+            """Returns Zarr attributes."""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 
@@ -79,7 +79,7 @@ class ZarrPlugin(Plugin):
             chunk: str = Path(description='Zarr chunk'),
             dataset: xr.Dataset = Depends(deps.dataset),
             cache: cachey.Cache = Depends(deps.cache),
-        ):
+        ) -> bytes:
             """Get a zarr array chunk.
 
             This will return cached responses when available.

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -79,7 +79,7 @@ class ZarrPlugin(Plugin):
             chunk: str = Path(description='Zarr chunk'),
             dataset: xr.Dataset = Depends(deps.dataset),
             cache: cachey.Cache = Depends(deps.cache),
-        ) -> bytes:
+        ):
             """Get a zarr array chunk.
 
             This will return cached responses when available.

--- a/xpublish/plugins/manage.py
+++ b/xpublish/plugins/manage.py
@@ -10,9 +10,13 @@ from .hooks import Plugin
 def find_default_plugins(
     exclude_plugins: Optional[Iterable[str]] = None,
 ) -> Dict[str, Type[Plugin]]:
-    """Find Xpublish plugins from entry point group `xpublish.plugin`
+    """Find Xpublish plugins from entry point group `xpublish.plugin`.
 
-    Individual plugins may be ignored by adding them to `exclude_plugins`.
+    Args:
+        exclude_plugins: A list of plugin names to ignore.
+
+    Returns:
+        A dictionary of plugin names and classes.
     """
     exclude_plugins = set(exclude_plugins or [])
 
@@ -33,7 +37,14 @@ def find_default_plugins(
 def load_default_plugins(
     exclude_plugins: Optional[Iterable[str]] = None,
 ) -> Dict[str, Plugin]:
-    """Find and initialize plugins from entry point group `xpublish.plugin`"""
+    """Find and initialize plugins from entry point group `xpublish.plugin`.
+
+    Args:
+        exclude_plugins: A list of plugin names to ignore.
+
+    Returns:
+        A dictionary of plugin names and instances.
+    """
     initialized_plugins: Dict[str, Plugin] = {}
 
     for name, plugin in find_default_plugins(exclude_plugins=exclude_plugins).items():
@@ -44,9 +55,17 @@ def load_default_plugins(
 
 def configure_plugins(
     plugins: Dict[str, Type[Plugin]],
-    plugin_configs: Optional[Dict] = None,
+    plugin_configs: Optional[Dict[str, Dict]] = None,
 ) -> Dict[str, Plugin]:
-    """Initialize and configure plugins with given dictionary of configurations"""
+    """Initialize and configure plugins with given dictionary of configurations.
+
+    Args:
+        plugins: A dictionary of plugin names and classes.
+        plugin_configs: A dictionary of plugin names and configurations.
+
+    Returns:
+        A dictionary of plugin names and instances.
+    """
     initialized_plugins: Dict[str, Plugin] = {}
     plugin_configs = plugin_configs or {}
 

--- a/xpublish/plugins/manage.py
+++ b/xpublish/plugins/manage.py
@@ -1,5 +1,4 @@
-"""Load and configure Xpublish plugins from entry point group `xpublish.plugin`
-"""
+"""Load and configure Xpublish plugins from entry point group `xpublish.plugin`."""
 from importlib.metadata import entry_points
 from typing import Dict, Iterable, Optional, Type
 

--- a/xpublish/plugins/manage.py
+++ b/xpublish/plugins/manage.py
@@ -1,5 +1,4 @@
-"""
-Load and configure Xpublish plugins from entry point group `xpublish.plugin`
+"""Load and configure Xpublish plugins from entry point group `xpublish.plugin`
 """
 from importlib.metadata import entry_points
 from typing import Dict, Iterable, Optional, Type

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -270,11 +270,11 @@ class Rest:
 
     @property
     def plugins(self) -> Dict[str, Plugin]:
-        """Returns the loaded plugins"""
+        """Returns the loaded plugins."""
         return dict(self.pm.list_name_plugin())
 
     def _init_routers(self, dataset_routers: Optional[APIRouter]) -> None:
-        """Setup plugin and dataset routers. Needs to run after dataset and plugin setup"""
+        """Setup plugin and dataset routers. Needs to run after dataset and plugin setup."""
         app_routers, plugin_dataset_routers = self.plugin_routers()
 
         if self._dataset_route_prefix:
@@ -291,7 +291,7 @@ class Rest:
         self._app_routers = app_routers
 
     def plugin_routers(self) -> Tuple[List[RouterAndKwargs], List[RouterAndKwargs]]:
-        """Load the app and dataset routers for plugins
+        """Load the app and dataset routers for plugins.
 
         Returns:
             A tuple containing a list of top-level routers from plugins
@@ -393,6 +393,7 @@ class Rest:
 
 class SingleDatasetRest(Rest):
     """Used to publish a single Xarray dataset via a REST API (FastAPI application).
+
     Use :class:`xpublish.Rest` to publish multiple datasets.
     """
 
@@ -430,7 +431,7 @@ class SingleDatasetRest(Rest):
         super().__init__({}, routers, cache_kws, app_kws, plugins)
 
     def setup_datasets(self, datasets) -> str:
-        """Modifies dataset loading to instead connect to the single dataset"""
+        """Modifies dataset loading to instead connect to the single dataset."""
         self._dataset_route_prefix = ''
         self._datasets = {}
 

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -204,8 +204,7 @@ class Rest:
         plugin_name: Optional[str] = None,
         overwrite: bool = False,
     ) -> None:
-        """
-        Register a plugin with the xpublish system.
+        """Register a plugin with the xpublish system.
 
         Args:
             plugin: Instantiated Plugin object.
@@ -265,7 +264,6 @@ class Rest:
     @property
     def cache(self) -> cachey.Cache:
         """Returns the :class:`cachey.Cache` instance used by the FastAPI application."""
-
         if self._cache is None:
             self._cache = cachey.Cache(**self._cache_kws)
         return self._cache
@@ -344,7 +342,6 @@ class Rest:
         Returns:
             FastAPI application instance.
         """
-
         self._app = FastAPI(**self._app_kws)
 
         self._init_routers(self._routers)

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -1,13 +1,36 @@
-from typing import Dict, List, Optional, Tuple
+from typing import (
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import cachey
 import pluggy
 import uvicorn
 import xarray as xr
-from fastapi import APIRouter, FastAPI, HTTPException, Path
+from fastapi import (
+    APIRouter,
+    FastAPI,
+    HTTPException,
+    Path,
+)
 
-from .dependencies import get_cache, get_dataset, get_dataset_ids, get_plugin_manager
-from .plugins import Dependencies, Plugin, PluginSpec, get_plugins, load_default_plugins
+from .dependencies import (
+    get_cache,
+    get_dataset,
+    get_dataset_ids,
+    get_plugin_manager,
+)
+from .plugins import (
+    Dependencies,
+    Plugin,
+    PluginSpec,
+    get_plugins,
+    load_default_plugins,
+)
 from .routers import dataset_collection_router
 from .utils.api import (
     SingleDatasetOpenAPIOverrider,
@@ -18,6 +41,7 @@ from .utils.api import (
 
 RouterKwargs = Dict
 RouterAndKwargs = Tuple[APIRouter, RouterKwargs]
+LogLevels = Literal['critical', 'error', 'warning', 'info', 'debug', 'trace']
 
 
 class Rest:
@@ -28,72 +52,74 @@ class Rest:
     Additionally the :class:`xpublish.SingleDatasetRest` class allows has
     a simplified interface for single dataset access.
 
-    Parameters
-    ----------
-    datasets :
-        A mapping of datasets objects to be served. If a mapping is given, keys
-        are used as dataset ids and are converted to strings. See also the notes below.
-    routers :
-        A list of dataset-specific :class:`fastapi.APIRouter` instances to
-        include in the fastAPI application. These routers are in addition
-        to any loaded via plugins.
-        The items of the list may also be tuples with the following format:
-        ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``, where
-        the 1st tuple element is a :class:`fastapi.APIRouter` instance and the
-        2nd element is a dictionary that is used to pass keyword arguments to
-        :meth:`fastapi.FastAPI.include_router`.
-    cache_kws :
-        Dictionary of keyword arguments to be passed to
-        :meth:`cachey.Cache.__init__()`.
-        By default, the cache size is set to 1MB, but this can be changed with
-        ``available_bytes``.
-    app_kws :
-        Dictionary of keyword arguments to be passed to
-        :meth:`fastapi.FastAPI.__init__()`.
-    plugins :
-        Optional dictionary of loaded, configured plugins.
-        Overrides automatic loading of plugins.
-        If no plugins are desired, set to an empty dict.
-
-    Notes
-    -----
-    The urls of the application's API endpoints differ whether a single dataset
-    or a mapping (collection) of datasets is given. In the latter case, all
-    dataset-specific endpoint urls have the prefix ``/datasets/{dataset_id}``,
+    NOTE: The urls of the application's API endpoints differ whether a single
+    dataset or a mapping (collection) of datasets is given. In the latter case,
+    all dataset-specific endpoint urls have the prefix ``/datasets/{dataset_id}``,
     where ``{dataset_id}`` corresponds to the keys of the mapping (converted to
-    strings). Still in the latter case, the endpoint ``/datasets`` is added and returns
-    the list of all dataset ids.
-
+    strings). Still in the latter case, the endpoint ``/datasets`` is added and
+    returns the list of all dataset ids.
     """
 
     def __init__(
         self,
         datasets: Optional[Dict[str, xr.Dataset]] = None,
-        routers: Optional[APIRouter] = None,
+        routers: Optional[Union[APIRouter, List[APIRouter]]] = None,
         cache_kws: Optional[Dict] = None,
         app_kws: Optional[Dict] = None,
         plugins: Optional[Dict[str, Plugin]] = None,
     ):
+        """Initialize a REST object for publishing Xarray Datasets.
+
+        Args:
+            datasets: A mapping of datasets objects to be served. If a mapping is
+                given, keys are used as dataset ids and are converted to strings.
+                See also the notes below.
+            routers: A list of dataset-specific :class:`fastapi.APIRouter`
+                instances to include in the fastAPI application. These routers are
+                in addition to any loaded via plugins. The items of the list may
+                also be tuples with the following format:
+                ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``, where
+                the 1st tuple element is a :class:`fastapi.APIRouter` instance and
+                the 2nd element is a dictionary that is used to pass keyword
+                arguments to :meth:`fastapi.FastAPI.include_router`.
+            cache_kws: Dictionary of keyword arguments to be passed to
+                :meth:`cachey.Cache.__init__()`. By default, the cache size is set
+                to 1MB, but this can be changed with ``available_bytes``.
+            app_kws: Dictionary of keyword arguments to be passed to
+                :meth:`fastapi.FastAPI.__init__()`.
+            plugins: Optional dictionary of loaded, configured plugins. Overrides
+                automatic loading of plugins. If no plugins are desired, set to an
+                empty dict.
+        """
         if isinstance(datasets, xr.Dataset):
             raise TypeError(
-                'xpublish.Rest no longer directly handles single datasets. Please use xpublish.SingleDatasetRest instead'
+                'xpublish.Rest no longer directly handles single datasets. '
+                'Please use xpublish.SingleDatasetRest instead'
             )
 
         self.setup_datasets(datasets or {})
         self.setup_plugins(plugins)
 
-        routers = normalize_app_routers(
+        if not routers:
+            routers = []
+        elif isinstance(routers, APIRouter):
+            routers = [routers]
+
+        normalized_routers: List[Tuple[APIRouter, Dict]] = normalize_app_routers(
             routers or [],
             self._dataset_route_prefix,
         )
-        check_route_conflicts(routers)
-        self._routers = routers
+        check_route_conflicts(normalized_routers)
+        self._routers = normalized_routers
 
         self.init_app_kwargs(app_kws)
         self.init_cache_kwargs(cache_kws)
 
     def setup_datasets(self, datasets: Dict[str, xr.Dataset]) -> str:
-        """Initialize datasets and dataset accessor function
+        """Initialize datasets and dataset accessor function.
+
+        Args:
+            datasets: Dictionary of datasets to serve with their names as keys.
 
         Returns:
             Prefix for dataset routers
@@ -125,15 +151,16 @@ class Rest:
         self,
         dataset_id: str = Path(description='Unique ID of dataset'),
     ) -> xr.Dataset:
-        """Attempt to load dataset from plugins, otherwise return dataset from passed in dictionary of datasets
+        """Attempts to load dataset from plugins.
 
-        Parameters:
-            dataset_id:
-                Unique key of dataset to attempt to load from plugins or
+        Otherwise return dataset from passed in dictionary of datasets.
+
+        Args:
+            dataset_id: Unique key of dataset to attempt to load from plugins or
                 those provided to :class:`xpublish.Rest` at initialization.
 
         Returns:
-            Dataset for selected ``dataset_id``
+            Dataset for selected ``dataset_id``.
 
         Raises:
             FastAPI.HTTPException: When a dataset is not found a 404 error is returned.
@@ -154,13 +181,10 @@ class Rest:
     ) -> None:
         """Initialize and load plugins from entry_points unless explicitly provided
 
-        Parameters:
-            plugins:
-                If a dictionary of initialized plugins is provided,
-                then the automatic loading of plugins is disabled.
-
-                Providing an empty dictionary will also disable
-                automatic loading of plugins.
+        Args:
+            plugins: A dictionary of initialized plugins. If provided,
+                then the automatic loading of plugins is disabled. Providing an
+                empty dictionary will also disable automatic loading of plugins.
         """
         if plugins is None:
             plugins = load_default_plugins()
@@ -181,18 +205,18 @@ class Rest:
         overwrite: bool = False,
     ) -> None:
         """
-        Register a plugin with the xpublish system
+        Register a plugin with the xpublish system.
 
         Args:
-            plugin: Instantiated Plugin object
-            plugin_name: Plugin name
+            plugin: Instantiated Plugin object.
+            plugin_name: Plugin name.
             overwrite: If a plugin of the same name exist,
                 setting this to True will remove the existing plugin before
                 registering the new plugin. Defaults to False.
 
         Raises:
-            AttributeError: Plugin can not be registered
-            ValueError: Plugin already registered, try setting overwrite to True
+            AttributeError: Plugin can not be registered.
+            ValueError: Plugin already registered, try setting overwrite to True.
         """
         plugin_name = plugin_name or plugin.name
 
@@ -216,15 +240,23 @@ class Rest:
         )():
             self.pm.add_hookspecs(hookspec)
 
-    def init_cache_kwargs(self, cache_kws: dict) -> None:
-        """Set up cache kwargs"""
+    def init_cache_kwargs(self, cache_kws: Union[dict, None]) -> None:
+        """Set up cache kwargs.
+
+        Args:
+            cache_kws: Dictionary of cache keyword arguments.
+        """
         self._cache = None
         self._cache_kws = {'available_bytes': 1e6}
         if cache_kws is not None:
             self._cache_kws.update(cache_kws)
 
-    def init_app_kwargs(self, app_kws: dict) -> None:
-        """Set up FastAPI application kwargs"""
+    def init_app_kwargs(self, app_kws: Union[dict, None]) -> None:
+        """Set up FastAPI application kwargs.
+
+        Args:
+            app_kws: Dictionary of FastAPI application keyword arguments.
+        """
         self._app = None
         self._app_kws = {}
         if app_kws is not None:
@@ -281,7 +313,11 @@ class Rest:
         return app_routers, dataset_routers
 
     def dependencies(self) -> Dependencies:
-        """FastAPI dependencies to pass to plugin router methods"""
+        """FastAPI dependencies to pass to plugin router methods.
+
+        Returns:
+            initialized :class:xpublish.plugins.Dependencies object.
+        """
         deps = Dependencies(
             dataset_ids=self.get_datasets_from_plugins,
             dataset=self._get_dataset_func,
@@ -293,7 +329,7 @@ class Rest:
         return deps
 
     def _init_dependencies(self) -> None:
-        """Initialize dependencies"""
+        """Initialize dependencies."""
         deps = self.dependencies()
 
         self._app.dependency_overrides[get_dataset_ids] = deps.dataset_ids
@@ -303,7 +339,11 @@ class Rest:
         self._app.dependency_overrides[get_plugin_manager] = deps.plugin_manager
 
     def _init_app(self) -> FastAPI:
-        """Initiate the FastAPI application."""
+        """Initiate the FastAPI application.
+
+        Returns:
+            FastAPI application instance.
+        """
 
         self._app = FastAPI(**self._app_kws)
 
@@ -319,10 +359,9 @@ class Rest:
     def app(self) -> FastAPI:
         """Returns the :class:`fastapi.FastAPI` application instance.
 
-        Notes
-        -----
-        Plugins registered with :meth:`xpublish.Rest.register_plugin` after :meth:`xpublish.Rest.app`
-        is accessed or :meth:`xpublish.Rest.serve` is called once may not take effect.
+        NOTE: Plugins registered with :meth:`xpublish.Rest.register_plugin`
+        after :meth:`xpublish.Rest.app` is accessed or :meth:`xpublish.Rest.serve`
+        is called once may not take effect.
         """
         if self._app is None:
             self._app = self._init_app()
@@ -330,29 +369,21 @@ class Rest:
 
     def serve(
         self,
-        host: str = '0.0.0.0',
-        port: int = 9000,
-        log_level: str = 'debug',
+        host: Optional[str] = '0.0.0.0',
+        port: Optional[int] = 9000,
+        log_level: Optional[LogLevels] = 'debug',
         **kwargs,
     ) -> None:
         """Serve this FastAPI application via :func:`uvicorn.run`.
 
-        Parameters
-        ----------
-        host :
-            Bind socket to this host.
-        port :
-            Bind socket to this port.
-        log_level :
-            App logging level, valid options are
-            {'critical', 'error', 'warning', 'info', 'debug', 'trace'}.
-        **kwargs :
-            Additional arguments to be passed to :func:`uvicorn.run`.
+        NOTE: This method is blocking and does not return.
 
-        Notes
-        -----
-        This method is blocking and does not return.
-
+        Args:
+            host: Bind socket to this host.
+            port: Bind socket to this port.
+            log_level: App logging level, valid options are
+                {'critical', 'error', 'warning', 'info', 'debug', 'trace'}.
+            **kwargs: Additional arguments to be passed to :func:`uvicorn.run`.
         """
         uvicorn.run(
             self.app,
@@ -366,11 +397,6 @@ class Rest:
 class SingleDatasetRest(Rest):
     """Used to publish a single Xarray dataset via a REST API (FastAPI application).
     Use :class:`xpublish.Rest` to publish multiple datasets.
-
-    Parameters:
-    -----------
-    dataset :
-        A single :class:`xarray.Dataset` object to be served.
     """
 
     def __init__(
@@ -381,13 +407,33 @@ class SingleDatasetRest(Rest):
         app_kws: Optional[Dict] = None,
         plugins: Optional[Dict[str, Plugin]] = None,
     ):
+        """Initialize the SingleDatasetRest object.
+
+        Args:
+            dataset: A single :class:`xarray.Dataset` object to be served.
+            routers: A list of dataset-specific :class:`fastapi.APIRouter`
+                instances to include in the fastAPI application. These routers are
+                in addition to any loaded via plugins. The items of the list may
+                also be tuples with the following format:
+                ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``, where
+                the 1st tuple element is a :class:`fastapi.APIRouter` instance and
+                the 2nd element is a dictionary that is used to pass keyword
+                arguments to :meth:`fastapi.FastAPI.include_router`.
+            cache_kws: Dictionary of keyword arguments to be passed to
+                :meth:`cachey.Cache.__init__()`. By default, the cache size is set
+                to 1MB, but this can be changed with ``available_bytes``.
+            app_kws: Dictionary of keyword arguments to be passed to
+                :meth:`fastapi.FastAPI.__init__()`.
+            plugins: Optional dictionary of loaded, configured plugins. Overrides
+                automatic loading of plugins. If no plugins are desired, set to an
+                empty dict.
+        """
         self._dataset = dataset
 
         super().__init__({}, routers, cache_kws, app_kws, plugins)
 
-    def setup_datasets(self, datasets) -> str:
-        """Modifies the dataset loading to instead connect to the
-        single dataset"""
+    def setup_datasets(self) -> str:
+        """Modifies dataset loading to instead connect to the single dataset"""
         self._dataset_route_prefix = ''
         self._datasets = {}
 

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -131,7 +131,7 @@ class Rest:
         return self._dataset_route_prefix
 
     def get_datasets_from_plugins(self) -> List[str]:
-        """Return dataset ids from directly loaded datasets and plugins
+        """Return dataset ids from directly loaded datasets and plugins.
 
         Used as a FastAPI dependency in dataset router plugins
         via :meth:`Rest.dependencies`.
@@ -179,7 +179,7 @@ class Rest:
         self,
         plugins: Optional[Dict[str, Plugin]] = None,
     ) -> None:
-        """Initialize and load plugins from entry_points unless explicitly provided
+        """Initialize and load plugins from entry_points unless explicitly provided.
 
         Args:
             plugins: A dictionary of initialized plugins. If provided,

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -63,7 +63,7 @@ class Rest:
     def __init__(
         self,
         datasets: Optional[Dict[str, xr.Dataset]] = None,
-        routers: Optional[Union[APIRouter, List[APIRouter]]] = None,
+        routers: Optional[List[APIRouter]] = None,
         cache_kws: Optional[Dict] = None,
         app_kws: Optional[Dict] = None,
         plugins: Optional[Dict[str, Plugin]] = None,
@@ -99,11 +99,6 @@ class Rest:
 
         self.setup_datasets(datasets or {})
         self.setup_plugins(plugins)
-
-        if not routers:
-            routers = []
-        elif isinstance(routers, APIRouter):
-            routers = [routers]
 
         normalized_routers: List[Tuple[APIRouter, Dict]] = normalize_app_routers(
             routers or [],
@@ -401,7 +396,7 @@ class SingleDatasetRest(Rest):
     def __init__(
         self,
         dataset: xr.Dataset,
-        routers: Optional[APIRouter] = None,
+        routers: Optional[List[APIRouter]] = None,
         cache_kws: Optional[Dict] = None,
         app_kws: Optional[Dict] = None,
         plugins: Optional[Dict[str, Plugin]] = None,

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -432,7 +432,7 @@ class SingleDatasetRest(Rest):
 
         super().__init__({}, routers, cache_kws, app_kws, plugins)
 
-    def setup_datasets(self) -> str:
+    def setup_datasets(self, datasets) -> str:
         """Modifies dataset loading to instead connect to the single dataset"""
         self._dataset_route_prefix = ''
         self._datasets = {}

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -217,18 +217,19 @@ class Rest:
             AttributeError: Plugin can not be registered.
             ValueError: Plugin already registered, try setting overwrite to True.
         """
-        plugin_name = plugin_name or plugin.name
-
-        if overwrite is True and plugin_name in dict(self.pm.list_name_plugin()):
-            # If a plugin exist with the same name, unregister it.
-            # If configured using entry_points, the name of the
-            # entry_point should be the same as the plugin.name.
-            self.pm.unregister(name=plugin_name)
-
-        # Get existing plugins again
-        existing_plugins = self.pm.get_plugins()
         try:
+            plugin_name = plugin_name or plugin.name
+
+            if overwrite is True and plugin_name in dict(self.pm.list_name_plugin()):
+                # If a plugin exist with the same name, unregister it.
+                # If configured using entry_points, the name of the
+                # entry_point should be the same as the plugin.name.
+                self.pm.unregister(name=plugin_name)
+
+            # Get existing plugins again
+            existing_plugins = self.pm.get_plugins()
             self.pm.register(plugin, plugin_name)
+
         except AttributeError as e:
             raise AttributeError(
                 f'Plugin {plugin} is likely not initialized before registration'

--- a/xpublish/routers/common.py
+++ b/xpublish/routers/common.py
@@ -8,5 +8,5 @@ dataset_collection_router = APIRouter()
 
 @dataset_collection_router.get('/datasets')
 def get_dataset_collection_keys(ids: list = Depends(get_dataset_ids)) -> list[str]:
-    """Return all the currently known Dataset IDs"""
+    """Return all the currently known Dataset IDs."""
     return ids

--- a/xpublish/routers/common.py
+++ b/xpublish/routers/common.py
@@ -1,7 +1,4 @@
-"""
-Dataset-independent API routes.
-
-"""
+"""Dataset-independent API routes."""
 from fastapi import APIRouter, Depends
 
 from ..dependencies import get_dataset_ids

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -114,8 +114,7 @@ def check_route_conflicts(routers: List[Tuple[APIRouter, Dict]]) -> None:
 
 
 class SingleDatasetOpenAPIOverrider:
-    """Used to override the FastAPI application openapi specs when a single
-    dataset is published.
+    """Used to override the FastAPI application openapi specs when a single dataset is published.
 
     In this case, the "dataset_id" path parameter is not present in API
     endpoints and has to be removed manually.
@@ -128,9 +127,11 @@ class SingleDatasetOpenAPIOverrider:
     """
 
     def __init__(self, app) -> None:
+        """Initialize the overrider."""
         self._app = app
 
     def openapi(self) -> dict:
+        """Override the FastAPI application openapi specs."""
         if self._app.openapi_schema:
             return self._app.openapi_schema
 
@@ -160,7 +161,10 @@ class SingleDatasetOpenAPIOverrider:
 
 
 class JSONResponse(StarletteJSONResponse):
+    """A JSON response that uses the same render kwargs as the JSONResponse class from Starlette."""
+
     def __init__(self, *args, **kwargs) -> None:
+        """Initialize the JSON response."""
         self._render_kwargs = {
             'ensure_ascii': True,
             'allow_nan': True,
@@ -171,4 +175,5 @@ class JSONResponse(StarletteJSONResponse):
         super().__init__(*args, **kwargs)
 
     def render(self, content: Any) -> bytes:
+        """Render the JSON response."""
         return json.dumps(content, **self._render_kwargs).encode('utf-8')

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -33,7 +33,7 @@ def normalize_datasets(datasets) -> Dict[str, xr.Dataset]:
 
 
 def normalize_app_routers(
-    routers: list,
+    routers: List[APIRouter],
     prefix: str,
 ) -> List[Tuple[APIRouter, Dict]]:
     """Normalise the given list of (dataset-specific) API routers.

--- a/xpublish/utils/cache.py
+++ b/xpublish/utils/cache.py
@@ -5,9 +5,11 @@ class CostTimer:
     """Context manager to measure wall time."""
 
     def __enter__(self):
+        """Start the timer."""
         self._start = time.perf_counter()
         return self
 
     def __exit__(self, *args):
+        """Stop the timer and return elapsed time."""
         end = time.perf_counter()
         self.time = end - self._start

--- a/xpublish/utils/cache.py
+++ b/xpublish/utils/cache.py
@@ -2,7 +2,7 @@ import time
 
 
 class CostTimer:
-    """Context manager to measure wall time"""
+    """Context manager to measure wall time."""
 
     def __enter__(self):
         self._start = time.perf_counter()

--- a/xpublish/utils/info.py
+++ b/xpublish/utils/info.py
@@ -1,6 +1,4 @@
-"""Utility functions for printing version information, adapted from
-xarray/util/print_versions.py
-"""
+"""Utility functions for printing version information, adapted from xarray/util/print_versions.py."""
 import locale
 import os
 import platform

--- a/xpublish/utils/info.py
+++ b/xpublish/utils/info.py
@@ -1,6 +1,5 @@
 """Utility functions for printing version information, adapted from
 xarray/util/print_versions.py
-
 """
 import locale
 import os
@@ -8,25 +7,35 @@ import platform
 import struct
 import subprocess
 import sys
-from typing import Union
+from typing import (
+    Any,
+    List,
+    Tuple,
+    Union,
+)
 
 
-def get_sys_info() -> list:
-    'Returns system information as a dict'
+def get_sys_info() -> List[Tuple[str, Any]]:
+    """Returns system information.
+
+    Returns:
+        A list of (key, value) tuples.
+    """
 
     blob = []
 
     # get full commit hash
     if os.path.isdir('.git') and os.path.isdir('xpublish'):
+        commit = None
         try:
             pipe = subprocess.Popen(
                 'git log --format="%H" -n 1'.split(' '),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-            so, serr = pipe.communicate()
+            so, _ = pipe.communicate()
         except Exception:  # pragma: no cover
-            commit = None
+            pass
         else:
             if pipe.returncode == 0:
                 commit = so
@@ -59,6 +68,11 @@ def get_sys_info() -> list:
 
 
 def netcdf_and_hdf5_versions() -> list[tuple[str, Union[str, None]]]:
+    """Returns netCDF and HDF5 version information.
+
+    Returns:
+        A list of (library, version) tuples.
+    """
     libhdf5_version = None
     libnetcdf_version = None
     try:

--- a/xpublish/utils/info.py
+++ b/xpublish/utils/info.py
@@ -21,7 +21,6 @@ def get_sys_info() -> List[Tuple[str, Any]]:
     Returns:
         A list of (key, value) tuples.
     """
-
     blob = []
 
     # get full commit hash

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -186,7 +186,6 @@ def create_zmetadata(dataset: xr.Dataset) -> dict:
     Returns:
         A consolidated zmetadata dictionary.
     """
-
     zmeta = {
         'zarr_consolidated_format': ZARR_CONSOLIDATED_FORMAT,
         'metadata': {},


### PR DESCRIPTION
Closes #186 
@abkfenris I will be a free-agent in a week or two, and plan to contribute in this ecosystem more heavily. I figured documenting and type-hinting the codebase would be an opportunity to refresh on the inner-workings.

**Changes:**
* I added [Ruff's `pydocstyle`](https://docs.astral.sh/ruff/settings/#pydocstyle) to our `pyproject.toml`. This includes docstring formatting as part of the pre-commit. I have it set to ignore the tests/ and docs/ directories as that seems fussy, but I am happy to cover those two as well. 
* I also have it set to ignore three [docstring rules](https://docs.astral.sh/ruff/rules/#pydocstyle-d), D100 (requires docstrings for all modules / .py files), D107 (requires docstrings for all __init__.py), and D104 (simular to D107, requires all packages to have a docstring). Happy to change this. I find module docstrings a bit overkill, especially as the name of the module should be semantically relevant, and all classes / functions have docstrings.
* I converted all docstrings to Google napolean style.
* I added typehints where missing, I also used `pyright` to make check that all typehints are correct, and fixed some bad ones.
* Very minor syntax changes to satisfy `pyright` best practices. No changes to logic.
* I added `pre-commit` to the dev environment requirements.txt. 