### PR TITLE
Convert zarr dependencies to utils, update numpy chunk encoding

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,7 +49,7 @@ def test_invalid_encoding_chunks_with_dask_raise():
     data = dask.array.zeros((10, 20, 30), chunks=expected)
     ds = xr.Dataset({'foo': (['x', 'y', 'z'], data)})
     ds['foo'].encoding['chunks'] = [8, 5, 1]
-    with pytest.raises(NotImplementedError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         _ = create_zmetadata(ds)
     excinfo.match(r'Specified zarr chunks .*')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,13 +54,12 @@ def test_invalid_encoding_chunks_with_dask_raise():
     excinfo.match(r'Specified zarr chunks .*')
 
 
-def test_invalid_encoding_chunks_with_numpy_raise():
+def test_ignore_encoding_chunks_with_numpy():
     data = np.zeros((10, 20, 30))
     ds = xr.Dataset({'foo': (['x', 'y', 'z'], data)})
     ds['foo'].encoding['chunks'] = [8, 5, 1]
-    with pytest.raises(ValueError) as excinfo:
-        _ = create_zmetadata(ds)
-    excinfo.match(r'Encoding chunks do not match inferred.*')
+    zmetadata = create_zmetadata(ds)
+    assert zmetadata['metadata']['foo/.zarray']['chunks'] == [10, 20, 30]
 
 
 def test_get_data_chunk_numpy():

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,9 +1,7 @@
-"""Helper functions to use a FastAPI dependencies."""
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    List,
-)
+"""
+Helper functions to use a FastAPI dependencies.
+"""
+from typing import TYPE_CHECKING, Dict, List
 
 import cachey
 import pluggy
@@ -11,14 +9,15 @@ import xarray as xr
 from fastapi import Depends
 
 from .utils.api import DATASET_ID_ATTR_KEY
-from .utils.zarr import ZARR_METADATA_KEY, create_zmetadata, create_zvariables
+from .utils.zarr import ZARR_METADATA_KEY
 
 if TYPE_CHECKING:
     from .plugins import Plugin  # pragma: no cover
 
 
 def get_dataset_ids() -> List[str]:
-    """FastAPI dependency for getting the list of ids (string keys) of the collection of datasets being served.
+    """FastAPI dependency for getting the list of ids (string keys)
+    of the collection of datasets being served.
 
     Use this callable as dependency in any FastAPI path operation
     function where you need access to those ids.
@@ -28,6 +27,7 @@ def get_dataset_ids() -> List[str]:
 
     Returns:
         A list of unique keys for datasets
+
     """
     return []  # pragma: no cover
 
@@ -66,67 +66,15 @@ def get_cache() -> cachey.Cache:
     return cachey.Cache(available_bytes=1e6)  # pragma: no cover
 
 
-def get_zvariables(
-    dataset: xr.Dataset = Depends(get_dataset),
-    cache: cachey.Cache = Depends(get_cache),
-) -> dict:
-    """FastAPI dependency that returns a dictionary of zarr encoded variables.
-
-    Args:
-        dataset: The dataset to get the zvariables from.
-        cache: The cache to use for storing the zvariables.
-
-    Returns:
-        A dictionary of zarr encoded variables.
-    """
-    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
-    zvariables = cache.get(cache_key)
-
-    if zvariables is None:
-        zvariables = create_zvariables(dataset)
-
-        # we want to permanently cache this: set high cost value
-        cache.put(cache_key, zvariables, 99999)
-
-    return zvariables
-
-
-def get_zmetadata(
-    dataset: xr.Dataset = Depends(get_dataset),
-    cache: cachey.Cache = Depends(get_cache),
-    zvariables: dict = Depends(get_zvariables),
-) -> dict:
-    """FastAPI dependency that returns a consolidated zmetadata dictionary.
-
-    Args:
-        dataset: The dataset to get the zmetadata from.
-        cache: The cache to use for storing the zmetadata.
-        zvariables: The zvariables to use for creating the zmetadata.
-
-    Returns:
-        A consolidated zmetadata dictionary.
-    """
-    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + ZARR_METADATA_KEY
-    zmeta = cache.get(cache_key)
-
-    if zmeta is None:
-        zmeta = create_zmetadata(dataset)
-
-        # we want to permanently cache this: set high cost value
-        cache.put(cache_key, zmeta, 99999)
-
-    return zmeta
-
-
 def get_plugins() -> Dict[str, 'Plugin']:
-    """FastAPI dependency that returns the a dictionary of loaded plugins.
+    """FastAPI dependency that returns the a dictionary of loaded plugins
 
     Returns:
         Dictionary of names to initialized plugins.
     """
+
     return {}  # pragma: no cover
 
 
 def get_plugin_manager() -> pluggy.PluginManager:
-    """Return the active plugin manager."""
-    ...
+    """Return the active plugin manager"""

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -1,15 +1,10 @@
-"""
-Helper functions to use a FastAPI dependencies.
+"""Helper functions to use a FastAPI dependencies.
 """
 from typing import TYPE_CHECKING, Dict, List
 
 import cachey
 import pluggy
 import xarray as xr
-from fastapi import Depends
-
-from .utils.api import DATASET_ID_ATTR_KEY
-from .utils.zarr import ZARR_METADATA_KEY
 
 if TYPE_CHECKING:
     from .plugins import Plugin  # pragma: no cover
@@ -72,7 +67,6 @@ def get_plugins() -> Dict[str, 'Plugin']:
     Returns:
         Dictionary of names to initialized plugins.
     """
-
     return {}  # pragma: no cover
 
 

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -7,12 +7,12 @@ from zarr.storage import attrs_key  # type: ignore
 
 from xpublish.utils.api import JSONResponse
 
-from ...dependencies import get_zmetadata, get_zvariables
+from ...utils.zarr import get_zmetadata, get_zvariables
 from .. import Dependencies, Plugin, hookimpl
 
 
 class DatasetInfoPlugin(Plugin):
-    """Dataset metadata and schema routes."""
+    """Dataset metadata"""
 
     name: str = 'dataset_info'
 
@@ -21,7 +21,6 @@ class DatasetInfoPlugin(Plugin):
 
     @hookimpl
     def dataset_router(self, deps: Dependencies) -> APIRouter:
-        """Returns a router with dataset metadata and schema routes."""
         router = APIRouter(
             prefix=self.dataset_router_prefix,
             tags=list(self.dataset_router_tags),
@@ -32,6 +31,7 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
         ) -> HTMLResponse:
             """Returns the xarray HTML representation of the dataset."""
+
             with xr.set_options(display_style='html'):
                 return HTMLResponse(dataset._repr_html_())
 
@@ -39,14 +39,15 @@ class DatasetInfoPlugin(Plugin):
         def list_keys(
             dataset=Depends(deps.dataset),
         ) -> list[str]:
-            """Returns a of the keys in a dataset."""
+            """List of the keys in a dataset"""
+
             return JSONResponse(list(dataset.variables))
 
         @router.get('/dict')
         def to_dict(
             dataset=Depends(deps.dataset),
         ) -> dict:
-            """Returns the full dataset as a dictionary."""
+            """The full dataset as a dictionary"""
             return JSONResponse(dataset.to_dict(data=False))
 
         @router.get('/info')
@@ -54,7 +55,8 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Returns the dataset schema (close to the NCO-JSON schema)."""
+            """Dataset schema (close to the NCO-JSON schema)."""
+
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -31,7 +31,6 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
         ) -> HTMLResponse:
             """Returns the xarray HTML representation of the dataset."""
-
             with xr.set_options(display_style='html'):
                 return HTMLResponse(dataset._repr_html_())
 
@@ -40,7 +39,6 @@ class DatasetInfoPlugin(Plugin):
             dataset=Depends(deps.dataset),
         ) -> list[str]:
             """List of the keys in a dataset"""
-
             return JSONResponse(list(dataset.variables))
 
         @router.get('/dict')
@@ -56,7 +54,6 @@ class DatasetInfoPlugin(Plugin):
             cache=Depends(deps.cache),
         ) -> dict:
             """Dataset schema (close to the NCO-JSON schema)."""
-
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -9,13 +9,14 @@ from zarr.storage import array_meta_key, attrs_key, group_meta_key  # type: igno
 
 from xpublish.utils.api import JSONResponse
 
-from ...dependencies import get_zmetadata, get_zvariables
 from ...utils.api import DATASET_ID_ATTR_KEY
 from ...utils.cache import CostTimer
 from ...utils.zarr import (
     ZARR_METADATA_KEY,
     encode_chunk,
     get_data_chunk,
+    get_zmetadata,
+    get_zvariables,
     jsonify_zmetadata,
 )
 from .. import Dependencies, Plugin, hookimpl
@@ -24,7 +25,7 @@ logger = logging.getLogger('zarr_api')
 
 
 class ZarrPlugin(Plugin):
-    """Adds Zarr-like accessing endpoints for datasets."""
+    """Adds Zarr-like accessing endpoints for datasets"""
 
     name: str = 'zarr'
 
@@ -33,7 +34,6 @@ class ZarrPlugin(Plugin):
 
     @hookimpl
     def dataset_router(self, deps: Dependencies) -> APIRouter:
-        """Returns a router with Zarr-like accessing endpoints for datasets."""
         router = APIRouter(
             prefix=self.dataset_router_prefix,
             tags=list(self.dataset_router_tags),
@@ -44,7 +44,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Returns consolidated Zarr metadata."""
+            """Consolidated Zarr metadata"""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 
@@ -57,7 +57,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Returns Zarr group data."""
+            """Zarr group data"""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 
@@ -68,7 +68,7 @@ class ZarrPlugin(Plugin):
             dataset=Depends(deps.dataset),
             cache=Depends(deps.cache),
         ) -> dict:
-            """Returns Zarr attributes."""
+            """Zarr attributes"""
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -36,11 +36,8 @@ ZARR_METADATA_KEY = '.zmetadata'
 logger = logging.getLogger('api')
 
 
-def get_zvariables(
-    dataset: xr.Dataset, cache: cachey.Cache
-):
+def get_zvariables(dataset: xr.Dataset, cache: cachey.Cache):
     """Returns a dictionary of zarr encoded variables, using the cache when possible."""
-
     cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
     zvariables = cache.get(cache_key)
 
@@ -59,7 +56,6 @@ def get_zmetadata(
     zvariables: dict,
 ):
     """Returns a consolidated zmetadata dictionary, using the cache when possible."""
-
     cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + ZARR_METADATA_KEY
     zmeta = cache.get(cache_key)
 
@@ -73,7 +69,7 @@ def get_zmetadata(
 
 
 def _extract_dataset_zattrs(dataset: xr.Dataset) -> dict:
-    """helper function to create zattrs dictionary from Dataset global attrs"""
+    """Helper function to create zattrs dictionary from Dataset global attrs"""
     zattrs = {}
     for k, v in dataset.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
@@ -85,7 +81,7 @@ def _extract_dataset_zattrs(dataset: xr.Dataset) -> dict:
 
 
 def _extract_dataarray_zattrs(da: xr.DataArray) -> dict:
-    """helper function to extract zattrs dictionary from DataArray"""
+    """Helper function to extract zattrs dictionary from DataArray"""
     zattrs = {}
     for k, v in da.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
@@ -102,7 +98,7 @@ def _extract_dataarray_coords(
     da: xr.DataArray,
     zattrs: dict,
 ) -> dict:
-    '''helper function to extract coords from DataArray into a directionary'''
+    '''Helper function to extract coords from DataArray into a directionary'''
     if da.coords:
         # Coordinates are only encoded if there are non-dimension coordinates
         nondim_coords = set(da.coords) - set(da.dims)
@@ -117,7 +113,7 @@ def _extract_fill_value(
     da: xr.DataArray,
     dtype: np.dtype,
 ) -> Any:
-    """helper function to extract fill value from DataArray."""
+    """Helper function to extract fill value from DataArray."""
     fill_value = da.attrs.pop('_FillValue', None)
     return encode_fill_value(fill_value, dtype)
 
@@ -127,7 +123,7 @@ def _extract_zarray(
     encoding: dict,
     dtype: np.dtype,
 ) -> dict:
-    """helper function to extract zarr array metadata."""
+    """Helper function to extract zarr array metadata."""
     meta = {
         'compressor': encoding.get('compressor', da.encoding.get('compressor', default_compressor)),
         'filters': encoding.get('filters', da.encoding.get('filters', None)),
@@ -169,7 +165,6 @@ def create_zvariables(dataset: xr.Dataset) -> dict:
 
 def create_zmetadata(dataset: xr.Dataset) -> dict:
     """Helper function to create a consolidated zmetadata dictionary."""
-
     zmeta = {
         'zarr_consolidated_format': ZARR_CONSOLIDATED_FORMAT,
         'metadata': {},
@@ -220,7 +215,7 @@ def encode_chunk(
     filters: Optional[list[Codec]] = None,
     compressor: Optional[Codec] = None,
 ) -> np.typing.ArrayLike:
-    """helper function largely copied from zarr.Array"""
+    """Helper function largely copied from zarr.Array"""
     # apply filters
     if filters:
         for f in filters:

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -142,11 +142,12 @@ def _extract_zarray(
     if meta['chunks'] is None:
         meta['chunks'] = da.shape
 
-    # validate chunks
+    # validate chunks for dask arrays, numpy arrays match the encoding to the shape
     if isinstance(da.data, DaskArrayType):
         var_chunks = tuple([c[0] for c in da.data.chunks])
     else:
         var_chunks = da.shape
+        meta['chunks'] = da.shape
     if not var_chunks == tuple(meta['chunks']):
         raise ValueError('Encoding chunks do not match inferred chunks')
 

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -2,13 +2,12 @@ import copy
 import logging
 from typing import (
     Any,
-    Dict,
     Optional,
 )
 
+import cachey
 import dask.array
 import numpy as np
-import numpy.typing as npt
 import xarray as xr
 from numcodecs.abc import Codec
 from numcodecs.compat import ensure_ndarray
@@ -37,15 +36,44 @@ ZARR_METADATA_KEY = '.zmetadata'
 logger = logging.getLogger('api')
 
 
+def get_zvariables(
+    dataset: xr.Dataset, cache: cachey.Cache
+):
+    """Returns a dictionary of zarr encoded variables, using the cache when possible."""
+
+    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
+    zvariables = cache.get(cache_key)
+
+    if zvariables is None:
+        zvariables = create_zvariables(dataset)
+
+        # we want to permanently cache this: set high cost value
+        cache.put(cache_key, zvariables, 99999)
+
+    return zvariables
+
+
+def get_zmetadata(
+    dataset: xr.Dataset,
+    cache: cachey.Cache,
+    zvariables: dict,
+):
+    """Returns a consolidated zmetadata dictionary, using the cache when possible."""
+
+    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + ZARR_METADATA_KEY
+    zmeta = cache.get(cache_key)
+
+    if zmeta is None:
+        zmeta = create_zmetadata(dataset)
+
+        # we want to permanently cache this: set high cost value
+        cache.put(cache_key, zmeta, 99999)
+
+    return zmeta
+
+
 def _extract_dataset_zattrs(dataset: xr.Dataset) -> dict:
-    """Helper function to create zattrs dictionary from Dataset global attrs.
-
-    Args:
-        dataset: The Dataset to extract zattrs from.
-
-    Returns:
-        A dictionary of zattrs.
-    """
+    """helper function to create zattrs dictionary from Dataset global attrs"""
     zattrs = {}
     for k, v in dataset.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
@@ -57,14 +85,7 @@ def _extract_dataset_zattrs(dataset: xr.Dataset) -> dict:
 
 
 def _extract_dataarray_zattrs(da: xr.DataArray) -> dict:
-    """Helper function to extract zattrs dictionary from DataArray.
-
-    Args:
-        da: The DataArray to extract zattrs from.
-
-    Returns:
-        A dictionary of zattrs.
-    """
+    """helper function to extract zattrs dictionary from DataArray"""
     zattrs = {}
     for k, v in da.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
@@ -81,15 +102,7 @@ def _extract_dataarray_coords(
     da: xr.DataArray,
     zattrs: dict,
 ) -> dict:
-    """Helper function to extract coords from DataArray into a directionary.
-
-    Args:
-        da: The DataArray to extract coords from.
-        zattrs: The zattrs dictionary to add coords to.
-
-    Returns:
-        A dictionary of zattrs with coords added.
-    """
+    '''helper function to extract coords from DataArray into a directionary'''
     if da.coords:
         # Coordinates are only encoded if there are non-dimension coordinates
         nondim_coords = set(da.coords) - set(da.dims)
@@ -104,15 +117,7 @@ def _extract_fill_value(
     da: xr.DataArray,
     dtype: np.dtype,
 ) -> Any:
-    """Helper function to extract fill value from DataArray.
-
-    Args:
-        da: The DataArray to extract fill value from.
-        dtype: The numpy dtype of the DataArray.
-
-    Returns:
-        The fill value of the DataArray.
-    """
+    """helper function to extract fill value from DataArray."""
     fill_value = da.attrs.pop('_FillValue', None)
     return encode_fill_value(fill_value, dtype)
 
@@ -122,16 +127,7 @@ def _extract_zarray(
     encoding: dict,
     dtype: np.dtype,
 ) -> dict:
-    """Helper function to extract zarr array metadata.
-
-    Args:
-        da: The DataArray to extract zarr array metadata from.
-        encoding: The encoding dictionary of the DataArray.
-        dtype: The numpy dtype of the DataArray.
-
-    Returns:
-        A dictionary of zarr array metadata.
-    """
+    """helper function to extract zarr array metadata."""
     meta = {
         'compressor': encoding.get('compressor', da.encoding.get('compressor', default_compressor)),
         'filters': encoding.get('filters', da.encoding.get('filters', None)),
@@ -159,33 +155,20 @@ def _extract_zarray(
     return meta
 
 
-def create_zvariables(dataset: xr.Dataset) -> Dict[str, xr.Variable]:
-    """Helper function to create a dictionary of zarr encoded variables.
-
-    Args:
-        dataset: The Dataset to encode variables from.
-
-    Returns:
-        A dictionary of zarr encoded xarray variables.
-    """
+def create_zvariables(dataset: xr.Dataset) -> dict:
+    """Helper function to create a dictionary of zarr encoded variables."""
     zvariables = {}
 
     for key, da in dataset.variables.items():
-        encoded_da: xr.Variable = encode_zarr_variable(da, name=key)
+        encoded_da = encode_zarr_variable(da, name=key)
         zvariables[key] = encoded_da
 
     return zvariables
 
 
 def create_zmetadata(dataset: xr.Dataset) -> dict:
-    """Helper function to create a consolidated zmetadata dictionary.
+    """Helper function to create a consolidated zmetadata dictionary."""
 
-    Args:
-        dataset: The Dataset to create zmetadata from.
-
-    Returns:
-        A consolidated zmetadata dictionary.
-    """
     zmeta = {
         'zarr_consolidated_format': ZARR_CONSOLIDATED_FORMAT,
         'metadata': {},
@@ -213,14 +196,9 @@ def jsonify_zmetadata(
     dataset: xr.Dataset,
     zmetadata: dict,
 ) -> dict:
-    """Helper function to convert zmetadata dict to a json compatible dict.
+    """Helper function to convert zmetadata dictionary to a json
+    compatible dictionary.
 
-    Args:
-        dataset: The Dataset to convert zmetadata from.
-        zmetadata: The zmetadata dict to convert.
-
-    Returns:
-        A json compatible zmetadata dict.
     """
     zjson = copy.deepcopy(zmetadata)
 
@@ -237,23 +215,11 @@ def jsonify_zmetadata(
 
 
 def encode_chunk(
-    chunk: npt.ArrayLike,
+    chunk: np.typing.ArrayLike,
     filters: Optional[list[Codec]] = None,
     compressor: Optional[Codec] = None,
-) -> npt.ArrayLike:
-    """Helper function largely copied from zarr.Array.
-
-    Args:
-        chunk: The chunk to encode.
-        filters: The filters to apply to the chunk.
-        compressor: The compressor to apply to the chunk.
-
-    Returns:
-        The encoded chunk.
-
-    Raises:
-        RuntimeError: If the chunk's dtype is not an object.
-    """
+) -> np.typing.ArrayLike:
+    """helper function largely copied from zarr.Array"""
     # apply filters
     if filters:
         for f in filters:
@@ -276,18 +242,10 @@ def get_data_chunk(
     da: xr.DataArray,
     chunk_id: str,
     out_shape: tuple,
-) -> npt.ArrayLike:
+) -> np.typing.ArrayLike:
     """Get one chunk of data from this DataArray (da).
 
     If this is an incomplete edge chunk, pad the returned array to match out_shape.
-
-    Args:
-        da: DataArray to get chunk from.
-        chunk_id: Chunk id to get.
-        out_shape: Shape of the output chunk.
-
-    Returns:
-        Chunk of data from this DataArray (da).
     """
     ikeys = tuple(map(int, chunk_id.split('.')))
     if isinstance(da, DaskArrayType):


### PR DESCRIPTION
We have been working on building a subset router (https://github.com/asascience-open/xreds/blob/fa3aa81e398c280cef34fd6e0846880df0bb2aef/xreds/plugins/subset_plugin.py#L138) which introduces a nested dataset router. The core zarr plugin did not work with this because of `zmetadata` and `zvariable` dependencies using the xpublish global `get_dataset` dependency. Instead this simply moves those functions to utils and removes the `Depends` functionality. If there is a better way to handle this i am all ears, I was not sure of why they were dependencies in the first place so this may be incorrect. 

This also includes a patch for numpy arrays when using the zarr router (https://github.com/xpublish-community/xpublish/issues/207). In some cases (especially kerchunk concatenated datasets) there may be a combination of numpy and dask arrays, and the numpy arrays may include encoding information even if the encoding is reset beforehand. This PR changes this functionality to force the encoding to match the array shape when the underlying array is not a dask array. 