### PR TITLE
Change 'compressor' encoding so that it contains 'id'

### DIFF
--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -184,6 +184,11 @@ def create_zmetadata(dataset: xr.Dataset) -> dict:
             encoding,
             encoded_da.dtype,
         )
+        compressor=zmeta['metadata'][f'{key}/{array_meta_key}'].get('compressor')
+        if compressor and type(compressor)==numcodecs.blosc.Blosc:
+            correct_comprdict=compressor.get_config()                
+            del zmeta['metadata'][f'{key}/{array_meta_key}']['compressor']
+            zmeta['metadata'][f'{key}/{array_meta_key}']['compressor']=correct_comprdict
 
     return zmeta
 


### PR DESCRIPTION
So this is based on many assumptions that I am too lazy to validate :) but it seems plausible to me and it fixes an issue:

If a [.zarray](https://github.com/xpublish-community/xpublish/blob/169e326cf60970bd3c6a38da1a2ceb88a6a37a78/xpublish/plugins/included/zarr.py#L94) of a variable is retrieved, a pure `dict` is returned. I am not sure what fastapi is doing with that, but obviously, the return is a JSON. If a compressor is set, I guess the `__dict__` representation of it is used.

The problem is, there is a difference between `cd` and `cc`, defined as:

```
import numcodecs
codec = numcodecs.Blosc(cname='zstd', clevel=5, shuffle=1, blocksize=0)
cd=codec.__dict__
cc=codec.get_config()
``` 

I assume that we want to have `cc` because it contains a `id` keyword. Without this, it is not clear that *blosc* was actually used. 
