### PR TITLE
Pin Zarr to <3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,13 +76,13 @@ jobs:
             ${{ runner.os }}-pip-dev
             ${{ runner.os }}-pip
 
+      # Disable Zarr upstream tests due to v3 changes git+https://github.com/zarr-developers/zarr \
       - name: Install dev dependencies
         run: |
           python -m pip install -r dev-requirements.txt
           python -m pip install --no-deps --upgrade \
                 git+https://github.com/dask/dask \
                 git+https://github.com/dask/cachey \
-                git+https://github.com/zarr-developers/zarr \
                 git+https://github.com/pydata/xarray \
                 git+https://github.com/tiangolo/fastapi \
                 git+https://github.com/encode/uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pluggy
 toolz
 uvicorn
 xarray!=v2023.09.0  # see https://github.com/xpublish-community/xpublish/issues/237
-zarr
+zarr<3


### PR DESCRIPTION
Zarr's updates for v3 have some new dependencies and have shuffled around some functionality that Xpublish uses, so lets limit the maximum version that Xpublish supports for now.