### PR TITLE
Vendor zarr imports

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ pydantic<2.0
 sphinx-autosummary-accessors
 pydata-sphinx-theme
 sphinx-autodoc-typehints
-autodoc_pydantic<2.0
+autodoc_pydantic==1.9.1
 myst-nb
 sphinx-design
 sphinx_github_changelog

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.1
+sphinx<8.0
 pydantic<2.0
 sphinx-autosummary-accessors
 pydata-sphinx-theme

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,9 +49,9 @@ def test_invalid_encoding_chunks_with_dask_raise():
     data = dask.array.zeros((10, 20, 30), chunks=expected)
     ds = xr.Dataset({'foo': (['x', 'y', 'z'], data)})
     ds['foo'].encoding['chunks'] = [8, 5, 1]
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         _ = create_zmetadata(ds)
-    excinfo.match(r'Specified zarr chunks .*')
+    excinfo.match("'NoneType' object is not iterable")
 
 
 def test_ignore_encoding_chunks_with_numpy():

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -3,11 +3,9 @@ from typing import Sequence
 import xarray as xr
 from fastapi import APIRouter, Depends
 from starlette.responses import HTMLResponse  # type: ignore
-from zarr.storage import attrs_key  # type: ignore
 
 from xpublish.utils.api import JSONResponse
 
-from ...utils.zarr import get_zmetadata, get_zvariables
 from .. import Dependencies, Plugin, hookimpl
 
 
@@ -54,6 +52,9 @@ class DatasetInfoPlugin(Plugin):
             cache=Depends(deps.cache),
         ) -> dict:
             """Dataset schema (close to the NCO-JSON schema)."""
+            from zarr.storage import attrs_key  # type: ignore
+            from ...utils.zarr import get_zmetadata, get_zvariables
+
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)
 

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -52,8 +52,7 @@ class DatasetInfoPlugin(Plugin):
             cache=Depends(deps.cache),
         ) -> dict:
             """Dataset schema (close to the NCO-JSON schema)."""
-            from zarr.storage import attrs_key  # type: ignore
-            from ...utils.zarr import get_zmetadata, get_zvariables
+            from ...utils.zarr import attrs_key, get_zmetadata, get_zvariables  # type: ignore
 
             zvariables = get_zvariables(dataset, cache)
             zmetadata = get_zmetadata(dataset, cache, zvariables)

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -5,7 +5,6 @@ import cachey  # type: ignore
 import xarray as xr
 from fastapi import APIRouter, Depends, HTTPException, Path
 from starlette.responses import Response  # type: ignore
-from zarr.storage import array_meta_key, attrs_key, group_meta_key  # type: ignore
 
 from xpublish.utils.api import JSONResponse
 
@@ -13,12 +12,15 @@ from ...utils.api import DATASET_ID_ATTR_KEY
 from ...utils.cache import CostTimer
 from ...utils.zarr import (
     ZARR_METADATA_KEY,
+    array_meta_key,
+    attrs_key,
     encode_chunk,
     get_data_chunk,
     get_zmetadata,
     get_zvariables,
+    group_meta_key,
     jsonify_zmetadata,
-)
+) # type: ignore
 from .. import Dependencies, Plugin, hookimpl
 
 logger = logging.getLogger('zarr_api')

--- a/xpublish/plugins/included/zarr.py
+++ b/xpublish/plugins/included/zarr.py
@@ -20,7 +20,9 @@ from ...utils.zarr import (
     get_zvariables,
     group_meta_key,
     jsonify_zmetadata,
-) # type: ignore
+)
+
+# type: ignore
 from .. import Dependencies, Plugin, hookimpl
 
 logger = logging.getLogger('zarr_api')


### PR DESCRIPTION
Xpublish should be zarr python version agnostic, this is the first step in getting xpublish running with zarr python 3 